### PR TITLE
Hotfix - Broken cart images

### DIFF
--- a/app/Http/Livewire/Components/Cart.php
+++ b/app/Http/Livewire/Components/Cart.php
@@ -96,7 +96,7 @@ class Cart extends Component
                 'identifier' => $line->purchasable->getIdentifier(),
                 'quantity' => $line->quantity,
                 'description' => $line->purchasable->getDescription(),
-                'thumbnail' => $line->purchasable->getThumbnail(),
+                'thumbnail' => $line->purchasable->getThumbnail()->getUrl(),
                 'option' => $line->purchasable->getOption(),
                 'options' => $line->purchasable->getOptions()->implode(' / '),
                 'sub_total' => $line->subTotal->formatted(),


### PR DESCRIPTION
Had to make this change on my local to fix images so figured you might appreciate it here as well hah. `getThumbnail()` otherwise tries to insert a full `<img>` tag into the `src` property