### PR TITLE
Require php 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^7.4|^8.0",
         "fruitcake/laravel-cors": "^2.0",
         "lunarphp/admin": "^0.1",
         "guzzlehttp/guzzle": "^7.0.1",


### PR DESCRIPTION
Arrow functions and typed properties are already used throughout the app, so at least 7.4 should be used.